### PR TITLE
Update draper dependency

### DIFF
--- a/spina-blog.gemspec
+++ b/spina-blog.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   ]
   s.test_files = Dir['spec/**/*']
 
-  s.add_runtime_dependency 'draper', '~> 3.0', '>= 3.0.0'
+  s.add_runtime_dependency 'draper', '>= 3.0.0', '<= 5.0'
   s.add_runtime_dependency 'friendly_id', '~> 5.2', '>= 5.2.1'
   s.add_runtime_dependency 'kaminari', '>= 1.0.1'
   s.add_runtime_dependency 'spina', '>= 1.0.0'


### PR DESCRIPTION
Just a dep update as draper 4 works the same primarily as draper 3 (drops Ruby 2.3 support).