### PR TITLE
German translations

### DIFF
--- a/app/views/spina/admin/blog/categories/index.html.erb
+++ b/app/views/spina/admin/blog/categories/index.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% else %>
     <div class="text-gray-700 italic">
-      There are no categories yet. Create your first one!
+      <%= t('spina.blog.categories.no_categories') %>
     </div>
   <% end %>
 </div>

--- a/app/views/spina/admin/blog/posts/_form_post_configuration.html.erb
+++ b/app/views/spina/admin/blog/posts/_form_post_configuration.html.erb
@@ -1,28 +1,28 @@
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:category)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:category), description: Spina::Blog::Post.human_attribute_name(:category_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :category) %>
   <%= f.select :category_id, Spina::Blog::Category.all.collect{|u| [u.name, u.id]}, {prompt: true}, class: 'form-select', data: {controller: "select-placeholder", action: "select-placeholder#update"} %>
 <% end %>
 
 <div class="border-t border-gray-200 my-6"></div>
 
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:draft), description: Spina::Blog::Post.human_attribute_name(:draft_description)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:draft), description: Spina::Blog::Post.human_attribute_name(:draft_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :draft) %>
   <%= render Spina::Forms::SwitchComponent.new(f, :draft) %>
 <% end %>
 
 <div class="border-t border-gray-200 my-6"></div>
 
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:featured), description: Spina::Blog::Post.human_attribute_name(:featured_description)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:featured), description: Spina::Blog::Post.human_attribute_name(:featured_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :featured) %>
   <%= render Spina::Forms::SwitchComponent.new(f, :featured) %>
 <% end %>
 
 <div class="border-t border-gray-200 my-6"></div>
 
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:slug), description: Spina::Blog::Category.human_attribute_name(:slug_description)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:slug), description: Spina::Blog::Post.human_attribute_name(:slug_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :slug) %>
   <%= render Spina::Forms::TextFieldComponent.new(f, :slug) %>
-  
+
   <% if @post.slug %>
     <div class="text-gray-400 text-xs mt-2">
       <%= t('spina.blog.posts.current_permalink', current_permalink: "/blog/posts/#{@post.slug}") %>
@@ -32,14 +32,14 @@
 
 <div class="border-t border-gray-200 my-6"></div>
 
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:published_at)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:published_at), description: Spina::Blog::Post.human_attribute_name(:published_at_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :published_at) %>
   <%= render Spina::Forms::TextFieldComponent.new(f, :published_at) %>
 <% end %>
 
 <div class="border-t border-gray-200 my-6"></div>
 
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Category.human_attribute_name(:spina_user)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:spina_user), description: Spina::Blog::Post.human_attribute_name(:spina_user_description)) do %>
   <%= render Spina::Forms::LabelComponent.new(f, :spina_user) %>
-  <%= f.select :user_id, Spina::User.all.collect{|u| [u.name, u.id]}, {prompt: true}, class: 'form-select', data: {controller: "select-placeholder", action: "select-placeholder#update"} %>  
+  <%= f.select :user_id, Spina::User.all.collect{|u| [u.name, u.id]}, {prompt: true}, class: 'form-select', data: {controller: "select-placeholder", action: "select-placeholder#update"} %>
 <% end %>

--- a/app/views/spina/admin/blog/posts/_form_post_configuration.html.erb
+++ b/app/views/spina/admin/blog/posts/_form_post_configuration.html.erb
@@ -25,8 +25,7 @@
   
   <% if @post.slug %>
     <div class="text-gray-400 text-xs mt-2">
-      Current permalink:
-      /blog/posts/<%= @post.slug %>
+      <%= t('spina.blog.posts.current_permalink', current_permalink: "/blog/posts/#{@post.slug}") %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/spina/admin/blog/posts/_form_post_seo.html.erb
+++ b/app/views/spina/admin/blog/posts/_form_post_seo.html.erb
@@ -1,7 +1,9 @@
-<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:seo_title), description: Spina::Blog::Post.human_attribute_name(:description)) do %>
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:seo_title), description: Spina::Blog::Post.human_attribute_name(:seo_title_description)) do %>
   <%= render Spina::Forms::TextFieldComponent.new(f, :seo_title) %>
-  
-  <div class="mt-5">
-    <%= render Spina::Forms::TextFieldComponent.new(f, :description) %>
-  </div>
+<% end %>
+
+<div class="border-t border-gray-200 my-6"></div>
+
+<%= render Spina::Forms::GroupComponent.new(label: Spina::Blog::Post.human_attribute_name(:description), description: Spina::Blog::Post.human_attribute_name(:description_description)) do %>
+  <%= render Spina::Forms::TextFieldComponent.new(f, :description) %>
 <% end %>

--- a/app/views/spina/admin/blog/posts/_post.html.erb
+++ b/app/views/spina/admin/blog/posts/_post.html.erb
@@ -1,27 +1,29 @@
 <div class="border-b border-gray-200 flex items-center justify-between space-x-8 pr-2">
-  
+
   <%= link_to spina.edit_admin_blog_post_path(post.id), class: 'flex items-center text-spina text-sm p-4 hover:text-spina-dark font-medium' do %>
     <% if post.featured? %>
       <%= heroicon('star', style: :solid, class: 'w-6 h-6 text-yellow-500 mr-3') %>
     <% end %>
     <div>
       <%= post.title %>
-      <div class="text-gray-400 text-xs"><%= time_ago_in_words(post.created_at) %> ago</div>
+      <div class="text-gray-400 text-xs">
+        <%= t('spina.blog.posts.created_at_in_words', date: time_ago_in_words(post.created_at)) %>
+      </div>
     </div>
   <% end %>
-  
+
   <div class="flex-1"></div>
-  
+
   <div>
     <% if post.draft? %>
       <span class="text-sm text-gray-400"><%=t 'spina.blog.posts.concept' %></span>
     <% elsif post.published_at and post.published_at > Time.now %>
       <span class="text-sm text-gray-400">
-        Will be published on <%= post.decorate.published_date %>
+        <%= t('spina.blog.posts.scheduled_publication_date', date: post.decorate.published_date) %>
       </span>
     <% end %>
   </div>
-  
+
   <div>
     <%= link_to spina.edit_admin_blog_post_path(post.id), class: "btn btn-default px-3" do %>
       <%= heroicon('pencil', style: :solid, class: 'w-4 h-4') %>

--- a/app/views/spina/admin/blog/posts/index.html.erb
+++ b/app/views/spina/admin/blog/posts/index.html.erb
@@ -4,16 +4,16 @@
       <%= heroicon('plus', style: :solid, class: 'w-6 h-6') %>
     <% end %>
   <% end %>
-  
+
   <% header.navigation do %>
     <nav class="-mb-3 mt-4">
       <ul class="inline-flex w-auto rounded-md bg-white">
         <%= render Spina::UserInterface::TabLinkComponent.new(t('spina.blog.posts.all_posts'), spina.admin_blog_posts_path, active: action_name == 'index') %>
-        
+
         <%= render Spina::UserInterface::TabLinkComponent.new(t('spina.blog.posts.live_posts'), spina.live_admin_blog_posts_path, active: action_name == 'live') %>
-        
+
         <%= render Spina::UserInterface::TabLinkComponent.new(t('spina.blog.posts.draft_posts'), spina.draft_admin_blog_posts_path, active: action_name == 'draft') %>
-        
+
         <%= render Spina::UserInterface::TabLinkComponent.new(t('spina.blog.posts.scheduled_posts'), spina.future_admin_blog_posts_path, active: action_name == 'future') %>
       </ul>
     </nav>
@@ -27,7 +27,7 @@
     </div>
   <% else %>
     <div class="text-gray-700 italic">
-      There are no posts yet. Create your first one!
+      <%= t('spina.blog.posts.no_posts') %>
     </div>
   <% end %>
 </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -55,6 +55,10 @@ de:
         excerpt: Auszug
         spina_user: Autor
         spina_user_description: Wähle den Autoren für diesen Blogeintrag aus
+        seo_title: SEO <title>
+        seo_title_description: Stelle sicher, dass Deine Suchresultate gut aussehen
+        description: Meta Beschreibung
+        description_description: Diese Beschreibung wird in den Suchergebnissen angezeigt
       spina/blog/category:
         name: Name der Kategorie
         name_placeholder: Name der Kategorie

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -20,6 +20,10 @@ de:
         live_posts: Veröffentlichte Blogeinträge
         post_seo: Suchmaschinen
         scheduled_posts: Geplante Blogeinträge
+        no_posts: Es sind noch keine Blogeinträge vorhanden. Erstelle jetzt den Ersten!
+        current_permalink: "Aktueller Permalink: %{current_permalink}"
+        scheduled_publication_date: "Wird am %{date} veröffentlicht"
+        created_at_in_words: "Erstellt: %{date} her"
 
       categories:
         title: Kategorien
@@ -29,6 +33,7 @@ de:
         saving: Wird gespeichert...
         saved: Kategorie gespeichert
         delete_confirmation: Bist Du sicher, dass Du <strong>%{subject}</strong> löschen möchtest?
+        no_categories: Es sind noch keine Kategorien vorhanden. Erstelle jetzt die Erste!
 
   activerecord:
     attributes:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,48 @@
+de:
+  spina:
+    view: Ansehen
+
+    blog:
+      title: Blog
+
+      posts:
+        title: Blogeinträge
+        new: Neuer Blogeintrag
+        save: Blogeintrag speichern
+        saving: Wird gespeichert...
+        saved: Blogeintrag gespeichert
+        post_content: Inhalt
+        post_configuration: Einstellungen
+        concept: Entwurf
+        all_posts: Alle Blogeinträge
+        delete_confirmation: Bist Du sicher, dass Du <strong>%{subject}</strong> löschen möchtest?
+        draft_posts: Entwürfe
+        live_posts: Veröffentlichte Blogeinträge
+        post_seo: Suchmaschinen
+        scheduled_posts: Geplante Blogeinträge
+
+      categories:
+        title: Kategorien
+        new: Neue Kategorie
+        name: Kategorien
+        save: Kategorie speichern
+        saving: Wird gespeichert...
+        saved: Kategorie gespeichert
+        delete_confirmation: Bist Du sicher, dass Du <strong>%{subject}</strong> löschen möchtest?
+
+  activerecord:
+    attributes:
+      spina/blog/post:
+        title: Titel
+        title_placeholder: Titel des Blogeintrags
+        content: Inhalt
+        draft: Entwurf
+        draft_description: Praktisch, wenn Deine Seite noch nicht ganz fertig ist
+        published_at: Veröffentlichungszeitpunkt
+        slug: Permalink
+        slug_description: Permalink-URL für diesen Blogeintrag
+        excerpt: Auszug
+        spina_user: Autor
+      spina/blog/category:
+        name: Name der Kategorie
+        name_placeholder: Name der Kategorie

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -38,16 +38,23 @@ de:
   activerecord:
     attributes:
       spina/blog/post:
+        category: Kategorie
+        category_description: Wähle die Kategorie für diesen Blogeintrag aus
         title: Titel
         title_placeholder: Titel des Blogeintrags
         content: Inhalt
         draft: Entwurf
         draft_description: Praktisch, wenn Deine Seite noch nicht ganz fertig ist
+        featured: Vorgestellt
+        featured_description: Hebe diesen Blogeintrag besonders hervor
         published_at: Veröffentlichungszeitpunkt
+        published_at_description: Lege den Zeitpunkt der Veröffentlichung fest
+        image: Bild
         slug: Permalink
         slug_description: Permalink-URL für diesen Blogeintrag
         excerpt: Auszug
         spina_user: Autor
+        spina_user_description: Wähle den Autoren für diesen Blogeintrag aus
       spina/blog/category:
         name: Name der Kategorie
         name_placeholder: Name der Kategorie

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -55,6 +55,10 @@ en:
         excerpt: Excerpt
         spina_user: Author
         spina_user_description: Choose the author of this post
+        seo_title: SEO <title>
+        seo_title_description: Make sure your search result looks good in search engines
+        description: Meta description
+        description_description: This description will be shown in search results
       spina/blog/category:
         name: Category name
         name_placeholder: Category name

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@ en:
         live_posts: Live Posts
         post_seo: Post SEO
         scheduled_posts: Scheduled Posts
+        no_posts: There are no posts yet. Create your first one!
+        current_permalink: "Current permalink: %{current_permalink}"
+        scheduled_publication_date: "Will be published on %{date}"
+        created_at_in_words: "Created: %{date} ago"
 
       categories:
         title: Categories
@@ -29,6 +33,7 @@ en:
         saving: Saving...
         saved: Category saved
         delete_confirmation: Are you sure you want to delete <strong>%{subject}</strong>?
+        no_categories: There are no categories yet. Create your first one!
 
   activerecord:
     attributes:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,16 +38,23 @@ en:
   activerecord:
     attributes:
       spina/blog/post:
+        category: Category
+        category_description: Choose the category for this post
         title: Post title
         title_placeholder: Post title
         content: Post content
         draft: Draft
         draft_description: Great for when your post is not quite finished
+        featured: Featured
+        featured_description: Feature this post
         published_at: Publishing date/time
+        published_at_description: Choose when this post was/will be published
+        image: Image
         slug: Permalink
         slug_description: Permalink URL for this post
         excerpt: Excerpt
         spina_user: Author
+        spina_user_description: Choose the author of this post
       spina/blog/category:
         name: Category name
         name_placeholder: Category name

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -20,6 +20,10 @@ nl:
         live_posts: Live Posts
         post_seo: Post SEO
         scheduled_posts: Scheduled Posts
+        no_posts: Er zijn nog geen berichten. Maak je eerste!
+        current_permalink: "Huidige permalink: %{current_permalink}"
+        scheduled_publication_date: "Zal worden gepubliceerd op %{date}"
+        created_at_in_words: "Created: %{date} geleden"
 
       categories:
         title: Categorieën
@@ -29,6 +33,7 @@ nl:
         saving: Opslaan...
         saved: Categorie opgeslagen
         delete_confirmation: Are you sure you want to delete <strong>%{subject}</strong>?
+        no_categories: Er zijn nog geen categorieën. Maak uw eerste aan!
 
   activerecord:
     attributes:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -38,16 +38,23 @@ nl:
   activerecord:
     attributes:
       spina/blog/post:
+        category: Categorie
+        category_description: Kies de categorie voor deze post
         title: Post titel
         title_placeholder: Post titel
         content: Post inhoud
         draft: Concept
         draft_description: Handig voor als je post nog niet helemaal af is
+        featured: Featured
+        featured_description: Feature this post
         published_at: Publicatiedatum/tijd
+        published_at_description: Kies wanneer deze post werd/wordt gepubliceerd
+        image: Afbeelding
         slug: Permalink
         slug_description: Permalink URL for this post
         excerpt: Uittreksel
         spina_user: Auteur
+        spina_user_description: Kies de auteur van deze post
         photo: Afbeelding
       spina/blog/category:
         name: Naam categorie

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -55,6 +55,10 @@ nl:
         excerpt: Uittreksel
         spina_user: Auteur
         spina_user_description: Kies de auteur van deze post
+        seo_title: SEO <title>
+        seo_title_description: Zorg ervoor dat je resultaat in Google er goed uit ziet
+        description: SEO Beschrijving
+        description_description: De beschrijving wordt weergegeven bij resultaten van zoekmachines
         photo: Afbeelding
       spina/blog/category:
         name: Naam categorie

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -55,6 +55,10 @@ pt-BR:
         excerpt: Resumo
         spina_user: Autor
         spina_user_description: Escolha o autor deste post
+        seo_title: SEO <title>
+        seo_title_description:
+        description: Meta descrição
+        description_description: Esta descrição será exibida nos resultados de busca
       spina/blog/category:
         name: Nome da categoria
         name_placeholder: Nome da categoria

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -38,16 +38,23 @@ pt-BR:
   activerecord:
     attributes:
       spina/blog/post:
+        category: Categoria
+        category_description: Escolha a categoria para este posto
         title: Título da Postagem
         title_placeholder: Título da Postagem
         content: Conteúdo da postagem
         draft: Rascunho
         draft_description: Ótimo quando sua postagem não está finalizada
+        featured: Featured
+        featured_description: Feature this post
         published_at: Data/hora da publicação
+        published_at_description: Escolha quando este post foi/virá a ser publicado
+        image: Imagem
         slug: Permalink
         slug_description: URL Permalink para esta postagem
         excerpt: Resumo
         spina_user: Autor
+        spina_user_description: Escolha o autor deste post
       spina/blog/category:
         name: Nome da categoria
         name_placeholder: Nome da categoria

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -20,6 +20,10 @@ pt-BR:
         live_posts: Live Posts
         post_seo: Post SEO
         scheduled_posts: Scheduled Posts
+        no_posts: Ainda não há postos. Crie seu primeiro!
+        current_permalink: "Link permanente atual: %{current_permalink}"
+        scheduled_publication_date: "Será publicado em %{date}"
+        created_at_in_words: "Criado: %{date} atrás"
 
       categories:
         title: Categorias
@@ -29,6 +33,7 @@ pt-BR:
         saving: Salvando...
         saved: Categoria salva
         delete_confirmation: Are you sure you want to delete <strong>%{subject}</strong>?
+        no_categories: Ainda não há categorias. Crie sua primeira!
 
   activerecord:
     attributes:


### PR DESCRIPTION
After finishing most of the basic work for a project using `spina`, I wanted to add a blog using the `spina-blog` gem.
Integration was easy, but then I was stopped by the missing german translations, as I'm using `config.i18n.raise_on_missing_translations = true` locally. So I've prepared the missing translations as a PR and I'm glad that I can give something back in a small way. 🙂

Apart from that almost all static texts from the views have been removed and replaced using translations from i18n as well.

There were also some places that used the wrong model, so the labels and so on were wrong when rendering the fields. This has been adjusted, some description translations have been added as well.

Finally the SEO tab has undergone some few cosmetic adjustments. The fields and labels have gotten some spacing between them, using the same styling like the settings tab is using.

Disclaimer: since my Portuguese and Dutch are a little bit rusty (read: not existent), I've used DeepL to translate the extra translations that were added during this PR. The existing ones have been left untouched. Happy to see some suggestions / corrections from native speakers! 😉