### PR TITLE
Add missing closing quotes

### DIFF
--- a/app/views/spina/blog/posts/_post.html.erb
+++ b/app/views/spina/blog/posts/_post.html.erb
@@ -1,4 +1,4 @@
-<li class="<%= dom_class(post) %>" id="<%= dom_id(post) %>>
+<li class="<%= dom_class(post) %>" id="<%= dom_id(post) %>">
   <h3><%= link_to post.title, spina.blog_post_path(post) %></h3>
   <%= post.excerpt&.html_safe %>
 </li>


### PR DESCRIPTION
Due to a missing closing quote, the link(s) in the provided post list of the index action were not rendered correctly. This PR adjusts the former behaviour.