### PR TITLE
Update specs

### DIFF
--- a/app/controllers/spina/admin/blog/posts_controller.rb
+++ b/app/controllers/spina/admin/blog/posts_controller.rb
@@ -9,7 +9,7 @@ module Spina
         before_action :set_breadcrumb
         before_action :set_tabs, only: %i[new create edit update]
         before_action :set_locale
-        
+
         admin_section :blog
 
         decorates_assigned :post

--- a/spec/controllers/spina/blog/posts_controller_spec.rb
+++ b/spec/controllers/spina/blog/posts_controller_spec.rb
@@ -52,7 +52,9 @@ RSpec.describe Spina::Blog::PostsController, type: :controller do
     context 'with a year' do
       let(:this_year_posts) do
         create_list :spina_blog_post, 3,
-                    draft: false, published_at: Time.zone.today.beginning_of_year
+                    draft: false,
+                    published_at: Time.zone.today.beginning_of_year
+
       end
       let(:last_year_posts) do
         create_list :spina_blog_post, 3,

--- a/spec/factories/spina/blog/posts.rb
+++ b/spec/factories/spina/blog/posts.rb
@@ -5,12 +5,16 @@ FactoryBot.define do
     sequence(:title) { |n| "Blog Post #{n}" }
     content { 'Some content for my post' }
     association :category, factory: :spina_blog_category
+    association :user, factory: :spina_user
 
     seo_title { 'Some title for SEO' }
     description { 'Some description for SEO' }
 
     factory :invalid_spina_blog_post do
-      title { nil }
+      title       { nil }
+      content     { nil }
+      user_id     { nil }
+      category_id { nil }
     end
   end
 end

--- a/spec/factories/spina/users.rb
+++ b/spec/factories/spina/users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :spina_user, class: Spina::User do
+    name             { 'Bram' }
+    sequence(:email) { |n| "bram#{n}@denkgroot.com" }
+    password         { 'password' }
+    password_confirmation { password }
+    admin { true }
+  end
+end

--- a/spec/models/spina/blog/category_spec.rb
+++ b/spec/models/spina/blog/category_spec.rb
@@ -2,20 +2,22 @@
 
 require 'rails_helper'
 
-module Spina::Blog
-  RSpec.describe Category, type: :model do
-    let(:category) { build(:spina_blog_category) }
+module Spina
+  module Blog
+    RSpec.describe Category, type: :model do
+      let(:category) { build(:spina_blog_category) }
 
-    subject { category }
+      subject { category }
 
-    it { is_expected.to be_valid }
-    it { expect { category.save }.to change(Spina::Blog::Category, :count).by(1) }
+      it { is_expected.to be_valid }
+      it { expect { category.save }.to change(Spina::Blog::Category, :count).by(1) }
 
-    context 'with invalid attributes' do
-      let(:category) { build(:invalid_spina_blog_category) }
+      context 'with invalid attributes' do
+        let(:category) { build(:invalid_spina_blog_category) }
 
-      it { is_expected.to_not be_valid }
-      it { expect { category.save }.to_not change(Spina::Blog::Category, :count) }
+        it { is_expected.to_not be_valid }
+        it { expect { category.save }.to_not change(Spina::Blog::Category, :count) }
+      end
     end
   end
 end

--- a/spec/models/spina/blog/post_spec.rb
+++ b/spec/models/spina/blog/post_spec.rb
@@ -2,37 +2,39 @@
 
 require 'rails_helper'
 
-module Spina::Blog
-  RSpec.describe Post, type: :model do
-    let(:post) { build(:spina_blog_post) }
+module Spina
+  module Blog
+    RSpec.describe Post, type: :model do
+      let(:post) { build(:spina_blog_post) }
 
-    subject { post }
+      subject { post }
 
-    it { is_expected.to be_valid }
-    it { expect { post.save }.to change(Spina::Blog::Post, :count).by(1) }
+      it { is_expected.to be_valid }
+      it { expect { post.save }.to change(Spina::Blog::Post, :count).by(1) }
 
-    context 'with invalid attributes' do
-      let(:post) { build(:invalid_spina_blog_post) }
+      context 'with invalid attributes' do
+        let(:post) { build(:invalid_spina_blog_post) }
 
-      it { is_expected.to_not be_valid }
-      it { expect { post.save }.to_not change(Spina::Blog::Post, :count) }
-    end
-
-    describe '.featured' do
-      let!(:post) { create(:spina_blog_post, featured: true) }
-      let!(:unfeatured) { create(:spina_blog_post) }
-
-      it 'returns 1 result' do
-        expect(Spina::Blog::Post.featured).to match_array [post]
+        it { is_expected.to_not be_valid }
+        it { expect { post.save }.to_not change(Spina::Blog::Post, :count) }
       end
-    end
 
-    describe '.unfeatured' do
-      let!(:post) { create(:spina_blog_post, featured: true) }
-      let!(:unfeatured) { create(:spina_blog_post) }
+      describe '.featured' do
+        let!(:post) { create(:spina_blog_post, featured: true) }
+        let!(:unfeatured) { create(:spina_blog_post) }
 
-      it 'returns 1 result' do
-        expect(Spina::Blog::Post.unfeatured).to match_array [unfeatured]
+        it 'returns 1 result' do
+          expect(Spina::Blog::Post.featured).to match_array [post]
+        end
+      end
+
+      describe '.unfeatured' do
+        let!(:post) { create(:spina_blog_post, featured: true) }
+        let!(:unfeatured) { create(:spina_blog_post) }
+
+        it 'returns 1 result' do
+          expect(Spina::Blog::Post.unfeatured).to match_array [unfeatured]
+        end
       end
     end
   end

--- a/spec/support/controller_helpers.rb
+++ b/spec/support/controller_helpers.rb
@@ -2,7 +2,7 @@
 
 module ControllerHelpers
   def sign_in
-    @account = Spina::Account.create name: 'My Website', preferences: {theme: 'default'}
+    @account = Spina::Account.create name: 'My Website', preferences: { theme: 'default' }
     @user = Spina::User.create name: 'admin', email: 'admin@example.com', password: 'password', admin: true
     request.session[:spina_user_id] = @user.id
   end
@@ -10,13 +10,13 @@ end
 
 module FeatureHelpers
   def sign_in
-    @account = Spina::Account.create name: 'My Website', preferences: {theme: 'default'}
+    @account = Spina::Account.create name: 'My Website', preferences: { theme: 'default' }
     @user = Spina::User.create name: 'admin', email: 'admin@example.com', password: 'password', admin: true
     visit '/admin/login'
     fill_in :email, with: @user.email
     fill_in :password, with: 'password'
     click_button 'Login'
-    expect(page).to have_content("Pages")
+    expect(page).to have_content('Pages')
   end
 end
 

--- a/spec/system/spina/admin/blog/posts_spec.rb
+++ b/spec/system/spina/admin/blog/posts_spec.rb
@@ -10,11 +10,13 @@ RSpec.feature 'Admin Posts', type: :system do
 
     it 'shows all the posts' do
       visit '/admin/blog/posts'
-      expect(page).to have_content "Blog Post"
+      expect(page).to have_content 'Blog Post'
     end
   end
 
   describe 'creating a post' do
+    let!(:category) { create(:spina_blog_category) }
+
     it 'creates a post', js: true do
       visit '/admin/blog/posts'
       find(:css, 'a[href="/admin/blog/posts/new"]').click
@@ -22,6 +24,11 @@ RSpec.feature 'Admin Posts', type: :system do
       find(
         :css, 'trix-editor[input*="content_input"]'
       ).set('Foobar')
+      within 'div[data-controller="tabs"]' do
+        click_on 'Settings'
+      end
+      select category.name, from: 'post[category_id]'
+      select @user.name, from: 'post[user_id]'
       click_on 'Save post'
       within 'nav[data-controller="navigation"]' do
         click_on 'Posts'


### PR DESCRIPTION
While digging deeper into this gem, I stumbled on the failing tests.
The root cause has nearly always been the missing `user_id` for a blog post, which is required to be existent since the `belongs_to :user` defined in the `post` model is not marked as `optional: true` (a change introduced with [Rails 5](https://www.bigbinary.com/blog/rails-5-makes-belong-to-association-required-by-default) after a [quick investigation](https://github.com/rails/rails/pull/18937)).
It's not an issue for `category_id`, as this is included in the factory and covers the presence in most cases (with exception of the system tests).

From my point of view there are two options how this can be treated in general and I'm happy to put this here for discussion (with partially prepared changes).

### 1. Mark the user and category as optional

The provided atom view checks for the presence of a user and includes the user's name if one has been set. So it seems to be a valid use case and I agree that it makes sense under some circumstances to leave the user unset in some cases. 

### 2. Let the user and category be mandatory

On the other hand it's rather usual (from my perspective) that a blog post has an author assigned in order to show related articles from this author. The same holds for categories, e.g. for better filtering. I think most writers / bloggers want their content to be found and seen.

### What has been done so far

To make the specs work for me, I went the second route. At least in terms of adjusting the specs. Based on that a `spina_user` factory has been introduced (shamelessly stolen from the `spina` gem 👮‍♂️) and used for the `spina_blog_post`. Also the system test for creating a `post` has been adapted to the UI.

To emphasise the second route, it is thinkable to make the model specs a little bit more expressive.
Also adding `NOT NULL` constraints on the database level could be an option here:

- Post: `user_id`, `category_id`, maybe also for `title` and `content` as they have a presence validation already in place
- Category: as `name`'s presence is also validated, a database constraint should not hurt

I was thinking about if this could be a breaking change, but as at least Spina 2.1.0 (which [requires at least Rails 6.1](https://github.com/SpinaCMS/Spina/blob/v2.1.0/Gemfile)) is required for this gem, there does not seem to be any peril here and most likely all users have been confronted with the requirements of choosing an user and a category for a blog post.
Which leaves still the option that someone has overwritten / extended the models themselves and mitigated the need to fill in these fields...🙈 

I'm looking forward to hear your thoughts / insights and happy to discuss this topic. 🙂
