### PR TITLE
Spina::Blog::CategoriesController inherits ::Spina::ApplicationController

### DIFF
--- a/app/controllers/spina/blog/categories_controller.rb
+++ b/app/controllers/spina/blog/categories_controller.rb
@@ -3,7 +3,7 @@
 module Spina
   module Blog
     # Spina::Blog::CategoriesController
-    class CategoriesController < ApplicationController
+    class CategoriesController < ::Spina::ApplicationController
       include ::Spina::Frontend
       
       before_action :page


### PR DESCRIPTION
This fix addresses an issue where CategoriesController threw an `undefined local variable or method 'current_theme' for Spina::Blog::CategoriesController`