### PR TITLE
renames depreciated tailwind_purge_content method

### DIFF
--- a/lib/spina/blog/engine.rb
+++ b/lib/spina/blog/engine.rb
@@ -13,7 +13,7 @@ module Spina
         end
         
         # Add views for purging Tailwind classes
-        ::Spina.config.tailwind_purge_content.concat Spina::Blog::Engine.root.glob("app/views/**/*.*")
+        ::Spina.config.tailwind_content.concat Spina::Blog::Engine.root.glob("app/views/**/*.*")
       end
 
       config.generators do |g|


### PR DESCRIPTION
`DEPRECATION WARNING: config.tailwind_purge_content has been renamed to config.tailwind_content (called from block in <class:Engine> at .../lib/spina/blog/engine.rb:16)`