### PR TITLE
custom view file location

### DIFF
--- a/app/controllers/spina/blog/categories_controller.rb
+++ b/app/controllers/spina/blog/categories_controller.rb
@@ -9,11 +9,12 @@ module Spina
       before_action :page
       before_action :category
       before_action :posts
+      before_action :set_theme
 
       def show
         respond_to do |format|
           format.atom
-          format.html { render layout: theme_layout }
+          format.html { render "#{@theme || 'spina'}/blog/categories/show", layout: theme_layout }
         end
       end
 
@@ -35,8 +36,12 @@ module Spina
         end
       end
       
+      def set_theme
+        @theme = current_theme.name.parameterize.underscore
+      end
+
       def theme_layout
-        "#{current_theme.name.parameterize.underscore}/application"
+        "#{@theme}/#{@page.layout_template || 'application'}"
       end
     end
   end

--- a/app/controllers/spina/blog/posts_controller.rb
+++ b/app/controllers/spina/blog/posts_controller.rb
@@ -8,6 +8,7 @@ module Spina
 
       before_action :find_posts, only: [:index]
       before_action :current_spina_user_can_view_page?
+      before_action :set_theme
 
       decorates_assigned :posts, :post
 
@@ -16,13 +17,13 @@ module Spina
 
         respond_to do |format|
           format.atom
-          format.html { render layout: theme_layout }
+          format.html { render "#{@theme || 'spina'}/blog/posts/index", layout: theme_layout }
         end
       end
 
       def show
         @post = Spina::Blog::Post.friendly.find params[:id]
-        render layout: theme_layout
+        render "#{@theme || 'spina'}/blog/posts/show", layout: theme_layout
       rescue ActiveRecord::RecordNotFound
         try_redirect
       end
@@ -46,8 +47,12 @@ module Spina
         start_date.end_of_year
       end
 
+      def set_theme
+        @theme = current_theme.name.parameterize.underscore
+      end
+
       def theme_layout
-        "#{current_theme.name.parameterize.underscore}/application"
+        "#{@theme}/#{@page.layout_template || 'application'}"
       end
 
       def page


### PR DESCRIPTION
I'm using the changes in this pull request in my live application and figured I'd see if you wanted to add them to the project. This allows spina view files to be unified into a `blog` directory under `app/views/<theme>/` instead of having custom blog views in a separate `app/views/spina/blog/` location. It also respects a layout_template attribute on the blog's Spina::Page record, which it previously did not do.

There may be a cleaner way to accomplish all this that I'm not aware of, hooking into SpinaCMS's engine code, which if true, I'm sure would be preferable. 