### PR TITLE
fix category dropdown to support view_component v3

### DIFF
--- a/app/views/spina/admin/blog/categories/_form.html.erb
+++ b/app/views/spina/admin/blog/categories/_form.html.erb
@@ -6,11 +6,11 @@
       <%= render Spina::Pages::TranslationsComponent.new(@category, label: @locale.upcase) %>
     
       <%= render Spina::UserInterface::DropdownComponent.new do |dropdown| %>
-        <% dropdown.button(classes: "btn btn-default px-3") do %>
+        <% dropdown.with_button(classes: "btn btn-default px-3") do %>
           <%= heroicon('dots-horizontal', style: :solid, class: "w-5 h-5 text-gray-600") %>
         <% end %>
         
-        <% dropdown.menu do %>
+        <% dropdown.with_menu do %>
           <%= button_to t('spina.permanently_delete'), spina.admin_blog_category_path(@category.id), method: :delete, class: "block w-full text-left px-4 py-2 text-sm leading-5 font-medium text-red-500 cursor-pointer bg-white hover:bg-red-100 hover:bg-opacity-50 hover:text-red-500 focus:outline-none focus:bg-gray-100 focus:text-gray-900", form: {data: {controller: "confirm", confirm_message: t('spina.blog.categories.delete_confirmation', subject: @category.name)}} %>
         <% end %>
       <% end %>


### PR DESCRIPTION
It seems that in previous PR [here](https://github.com/SpinaCMS/spina-blog/pull/37/files) the "categories" were missed, adding a fix to them in this one.