### PR TITLE
Copy/Paste and Drag/Drop of Images into Trix text editor

### DIFF
--- a/app/views/spina/admin/blog/posts/_form_post_content.html.erb
+++ b/app/views/spina/admin/blog/posts/_form_post_content.html.erb
@@ -7,7 +7,7 @@
   <div class="mt-1 relative">   
     <%= f.hidden_field :excerpt, id: "excerpt_input" %>
   
-    <div class="relative form-textarea p-4 shadow-sm max-w-5xl" data-controller="trix" id="insert_excerpt_trix-toolbar" data-action="media-picker:done->trix#insertAttachment">      
+    <div class="relative form-textarea p-4 shadow-sm max-w-5xl" data-controller="trix" id="insert_excerpt_trix-toolbar" data-action="media-picker:done->trix#insertAttachment trix-file-accept->trix#fileAccept">
       <%= render Spina::Forms::TrixToolbarComponent.new("excerpt_trix-toolbar") %>
       
       <trix-editor class="prose prose-sm focus:outline-none max-w-3xl xl:border-r border-dashed border-gray-200 pr-3" toolbar="excerpt_trix-toolbar" input="excerpt_input" data-trix-target="editor" data-action="trix-file-accept->trix#preventDefault"></trix-editor>
@@ -21,7 +21,7 @@
     
     <%= f.hidden_field :content, id: "content_input" %>
   
-    <div class="relative form-textarea p-4 shadow-sm max-w-5xl" data-controller="trix" id="insert_content_trix-toolbar" data-action="media-picker:done->trix#insertAttachment">      
+    <div class="relative form-textarea p-4 shadow-sm max-w-5xl" data-controller="trix" id="insert_content_trix-toolbar" data-action="media-picker:done->trix#insertAttachment trix-file-accept->trix#fileAccept">
       <%= render Spina::Forms::TrixToolbarComponent.new("content_trix-toolbar") %>
       
       <trix-editor class="prose prose-sm focus:outline-none max-w-3xl xl:border-r border-dashed border-gray-200 pr-3" toolbar="content_trix-toolbar" input="content_input" data-trix-target="editor" data-action="trix-file-accept->trix#preventDefault"></trix-editor>


### PR DESCRIPTION
Small frontend tweak to make use of new image copy/paste and drag-and-drop functionality added to Spina core. See https://github.com/SpinaCMS/Spina/pull/1278

![spina-blog-image-copy-paste-demo](https://github.com/SpinaCMS/spina-blog/assets/1912237/e5648193-52c1-4619-9ac2-738206a1176c)
