### PR TITLE
Typecast year as text so it doesn't append a .0

### DIFF
--- a/app/components/spina/blog/archived_posts_widget_component.rb
+++ b/app/components/spina/blog/archived_posts_widget_component.rb
@@ -24,7 +24,7 @@ module Spina
 
       def query
         <<~SQL
-        select extract('Year' from published_at) as published_at_year, count(extract('Year' from published_at))
+        select cast(extract('Year' from published_at) as text) as published_at_year, count(extract('Year' from published_at))
         from spina_blog_posts
         where draft=false
         group by published_at_year


### PR DESCRIPTION
Whoops. The query was returning the years as a float, so the year 2023 was printing as "2023.0". This typecasts it as a string so that doesn't happen.

You can see the widget in action on my blog [www.greenspudtrades.com](https://www.greenspudtrades.com/)
