### PR TITLE
Missing category atom view

### DIFF
--- a/app/controllers/spina/blog/categories_controller.rb
+++ b/app/controllers/spina/blog/categories_controller.rb
@@ -13,7 +13,7 @@ module Spina
 
       def show
         respond_to do |format|
-          format.atom
+          format.atom { render 'blog/posts/index' }
           format.html { render "#{@theme || 'spina'}/blog/categories/show", layout: theme_layout }
         end
       end

--- a/app/views/spina/blog/categories/show.atom.builder
+++ b/app/views/spina/blog/categories/show.atom.builder
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-atom_feed language: 'en-GB', url: spina.blog_root_url do |feed|
-  feed.title('Blog')
+atom_feed language: 'en-GB', url: spina.blog_category_url(@category) do |feed|
+  feed.title(@category.name)
   feed.updated(@posts[0].created_at) unless @posts.empty?
 
   render partial: 'post', collection: @posts, locals: { feed: feed }

--- a/app/views/spina/blog/categories/show.atom.builder
+++ b/app/views/spina/blog/categories/show.atom.builder
@@ -4,5 +4,5 @@ atom_feed language: 'en-GB', url: spina.blog_category_url(@category) do |feed|
   feed.title(@category.name)
   feed.updated(@posts[0].created_at) unless @posts.empty?
 
-  render partial: 'post', collection: @posts, locals: { feed: feed }
+  render partial: 'blog/posts/post', collection: @posts, locals: { feed: feed }
 end

--- a/app/views/spina/blog/posts/_post.atom.builder
+++ b/app/views/spina/blog/posts/_post.atom.builder
@@ -1,0 +1,10 @@
+feed.entry(post, published: post.published_at, url: spina.blog_post_url(post)) do |entry|
+  entry.title(post.title)
+  entry.content(post.content, type: 'html')
+
+  if post.user
+    entry.author do |author|
+      author.name(post.user.name)
+    end
+  end
+end

--- a/app/views/spina/blog/posts/index.atom.builder
+++ b/app/views/spina/blog/posts/index.atom.builder
@@ -4,5 +4,5 @@ atom_feed language: 'en-GB', url: spina.blog_root_url do |feed|
   feed.title('Blog')
   feed.updated(@posts[0].created_at) unless @posts.empty?
 
-  render partial: 'post', collection: @posts, locals: { feed: feed }
+  render partial: 'blog/posts/post', collection: @posts, locals: { feed: feed }
 end


### PR DESCRIPTION
While testing changes to view_paths (#47), I noticed the categories#show action responds to .atom, but doesn't provide a view for it. This moves the atom post builder into a partial and uses the partial in both posts#index and categories#show views